### PR TITLE
Domain and CORS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ package-lock.json
 __pycache__
 .pytest_cache
 .venv
+.env
 *.egg-info
 
 # CDK asset staging directory

--- a/app.py
+++ b/app.py
@@ -5,6 +5,14 @@ import aws_cdk as cdk
 
 from aws_change_observer.aws_change_observer_stack import AwsChangeObserverStack
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
+region = os.getenv("REGION")
+account = os.getenv("ACCOUNT")
+is_prod = os.getenv("PROD") == 'True'  # Convert string to boolean if needed
+
 
 app = cdk.App()
 AwsChangeObserverStack(app, "AwsChangeObserverStack",
@@ -20,7 +28,9 @@ AwsChangeObserverStack(app, "AwsChangeObserverStack",
     # Uncomment the next line if you know exactly what Account and Region you
     # want to deploy the stack to. */
 
-    #env=cdk.Environment(account='123456789012', region='us-east-1'),
+    env=cdk.Environment(account=account, region=region),
+
+    is_prod=is_prod,
 
     # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
     )

--- a/lambdas/add_marker_request/add_marker_request_lambda_function.py
+++ b/lambdas/add_marker_request/add_marker_request_lambda_function.py
@@ -25,6 +25,11 @@ def lambda_handler(event, context):
         logger.error("TABLE_NAME environment variable is not set.")
         return {
             'statusCode': 500,
+            'headers': {
+                'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+                'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+                'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+            },
             'body': json.dumps({'error': 'Server configuration error.'})
         }
 
@@ -35,12 +40,22 @@ def lambda_handler(event, context):
         logger.error(f"Invalid or missing body in the request: {e}")
         return {
             'statusCode': 400,
+            'headers': {
+                'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+                'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+                'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+            },
             'body': json.dumps({'error': 'Invalid request body.'})
         }
     except Exception as e:
         logger.error(f"Error creating LocationMarker from JSON: {e}")
         return {
             'statusCode': 400,
+            'headers': {
+                'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+                'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+                'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+            },
             'body': json.dumps({'error': 'Invalid marker data format.'})
         }
 
@@ -51,11 +66,21 @@ def lambda_handler(event, context):
         logger.info(f"Successfully added marker with ID: {saved_marker.get_marker_id()}")
         return {
             'statusCode': 201,
+            'headers': {
+                'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+                'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+                'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+            },
             'body': json.dumps({'message': 'Marker added successfully', 'marker': saved_marker.to_json()})
         }
     except Exception as e:
         logger.error(f"Failed to add marker to DynamoDB: {e}")
         return {
             'statusCode': 500,
+            'headers': {
+                'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+                'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+                'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+            },
             'body': json.dumps({'error': 'Failed to add marker to DynamoDB.'})
         }

--- a/lambdas/get_markers_request/get_markers_request_lambda_function.py
+++ b/lambdas/get_markers_request/get_markers_request_lambda_function.py
@@ -25,6 +25,11 @@ def lambda_handler(event, context):
         logger.error("TABLE_NAME environment variable is not set.")
         return {
             'statusCode': 500,
+            'headers': {
+                'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+                'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+                'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+            },
             'body': json.dumps({'error': 'Server configuration error.'})
         }
 
@@ -37,10 +42,20 @@ def lambda_handler(event, context):
         logger.error(f"Error retrieving markers: {e}")
         return {
             'statusCode': 500,
+            'headers': {
+                'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+                'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+                'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+            },
             'body': json.dumps({'error': 'Failed to retrieve markers.'})
         }
 
     return {
         'statusCode': 200,
+        'headers': {
+            'Access-Control-Allow-Origin': '*',  # Allow all origins for testing
+            'Access-Control-Allow-Methods': 'GET,OPTIONS',  # Allowed methods
+            'Access-Control-Allow-Headers': 'Content-Type',  # Allowed headers
+        },
         'body': json.dumps({'markers': [marker.to_json() for marker in markers]})
     }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest==6.2.5
+python-dotenv


### PR DESCRIPTION
- Add python-dotenv for environment variable management
- Set region, account ID, and is_prod in .env
- Enable CORS headers for API responses
- Configure and link Route 53 domain to API Gateway